### PR TITLE
Document required API key scopes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ Once the deployment has finished, you can release the app:
 foundry apps release
 ```
 
-Next, go to **Foundry** > **App catalog**, find your app, and install it. You will be requested to add the API credentials for the app, you can create them in Support and resources > API clients and keys.
+Next, go to **Foundry** > **App catalog**, find your app, and install it. You will be prompted to provide API credentials. Create an API client at **Support and resources** > **API clients and keys** with the following scopes:
+
+- **Alerts** - Read
+- **Message Center** - Read
 
 Once it's installed you can find the **Translation and custom context** extension in the right sidebar of detections:
 


### PR DESCRIPTION
The Getting Started section tells users to create API credentials during installation but doesn't specify which scopes are needed. This adds the required scopes (Alerts - Read, Message Center - Read) to match what's already documented in the in-app docs (`app_docs/README.md`).

Closes #77