### PR TITLE
Fail E2E test when API credential prompt is missing

### DIFF
--- a/e2e/src/pages/AppCatalogPage.ts
+++ b/e2e/src/pages/AppCatalogPage.ts
@@ -149,8 +149,7 @@ export class AppCatalogPage extends BasePage {
       const count = await textInputs.count();
       this.logger.info(`API integration configuration form detected with ${count} input fields`);
     } catch (error) {
-      this.logger.info('No API integration configuration required - no input fields found');
-      return;
+      throw new Error('This app should prompt for API credentials');
     }
 
     this.logger.info('API integration configuration required, filling Falcon API values');


### PR DESCRIPTION
The `configureApiIntegrationIfNeeded()` method silently returned when credential input fields weren't found during install. Since this app always requires API credentials, the test should fail if the prompt doesn't appear rather than passing with unconfigured credentials.