### PR TITLE
Fix Charlotte AI iframe conflict in e2e tests

### DIFF
--- a/e2e/src/pages/DetectionContextExplorerPage.ts
+++ b/e2e/src/pages/DetectionContextExplorerPage.ts
@@ -40,10 +40,10 @@ export class DetectionContextExplorerPage extends BasePage {
     this.logger.success(`Successfully navigated to Foundry app page`);
 
     try {
-      await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+      await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 15000 });
       this.logger.success('App iframe is visible');
 
-      const iframe = this.page.frameLocator('iframe');
+      const iframe = this.page.frameLocator('iframe[name="portal"]');
       const heading = iframe.getByRole('heading', { name: /Detection Context Explorer/i });
 
       await expect(heading).toBeVisible({ timeout: 10000 });
@@ -51,7 +51,7 @@ export class DetectionContextExplorerPage extends BasePage {
     } catch (error) {
       this.logger.warn(`App content not fully visible - may still be loading`);
 
-      const iframeExists = await this.page.locator('iframe').isVisible({ timeout: 3000 });
+      const iframeExists = await this.page.locator('iframe[name="portal"]').isVisible({ timeout: 3000 });
       if (iframeExists) {
         this.logger.info('Iframe exists but content may still be loading');
       } else {
@@ -138,7 +138,7 @@ export class DetectionContextExplorerPage extends BasePage {
         await this.retryPageLoadAfter404();
       }
 
-      const iframe = this.page.locator('iframe');
+      const iframe = this.page.locator('iframe[name="portal"]');
       await iframe.waitFor({ state: 'visible', timeout: 30000 });
       await this.verifyPageLoaded();
       return true;

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -48,7 +48,7 @@ test.describe('Detection Translation App E2E Tests', () => {
       await detectionContextExplorerPage.navigateToInstalledApp();
 
       // Verify iframe is present
-      const iframe = detectionContextExplorerPage.page.locator('iframe');
+      const iframe = detectionContextExplorerPage.page.locator('iframe[name="portal"]');
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
       logger.success('Detection Context Explorer iframe loaded successfully');
@@ -57,7 +57,7 @@ test.describe('Detection Translation App E2E Tests', () => {
     test('should verify app content renders without JavaScript errors', async ({ page }) => {
       await detectionContextExplorerPage.navigateToInstalledApp();
 
-      const iframe = page.frameLocator('iframe');
+      const iframe = page.frameLocator('iframe[name="portal"]');
       const contentArea = iframe.locator('body');
       await expect(contentArea).toBeVisible({ timeout: 15000 });
       logger.success('App content rendered without JavaScript errors');
@@ -66,10 +66,10 @@ test.describe('Detection Translation App E2E Tests', () => {
     test('should verify UI loads without errors', async ({ page }) => {
       await detectionContextExplorerPage.navigateToInstalledApp();
 
-      const iframe = page.locator('iframe');
+      const iframe = page.locator('iframe[name="portal"]');
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
-      const iframeContent = page.frameLocator('iframe');
+      const iframeContent = page.frameLocator('iframe[name="portal"]');
       const bodyContent = iframeContent.locator('body');
       await expect(bodyContent).toBeVisible({ timeout: 15000 });
 


### PR DESCRIPTION
Charlotte AI adds a second iframe to every Falcon console page, causing Playwright's strict mode to fail with "locator('iframe') resolved to 2 elements". This updates all iframe selectors to use `iframe[name="portal"]` to target the Foundry app iframe specifically.

All changes are in the `e2e/` directory.