### PR TITLE
Fix CVE: add brace-expansion 1.1.13 override

### DIFF
--- a/ui/extensions/translation-and-context/package.json
+++ b/ui/extensions/translation-and-context/package.json
@@ -21,6 +21,7 @@
       "flatted": "3.4.2",
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
+      "brace-expansion@1": "1.1.13",
       "brace-expansion@5": "5.0.5"
     }
   },

--- a/ui/extensions/translation-and-context/pnpm-lock.yaml
+++ b/ui/extensions/translation-and-context/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   flatted: 3.4.2
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
+  brace-expansion@1: 1.1.13
   brace-expansion@5: 5.0.5
 
 importers:
@@ -1206,8 +1207,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -3693,7 +3694,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -4433,7 +4434,7 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@9.0.7:
     dependencies:

--- a/ui/pages/detection-context-explorer/package.json
+++ b/ui/pages/detection-context-explorer/package.json
@@ -50,6 +50,7 @@
       "flatted": "3.4.2",
       "picomatch@2": "2.3.2",
       "picomatch@4": "4.0.4",
+      "brace-expansion@1": "1.1.13",
       "brace-expansion@5": "5.0.5"
     }
   },

--- a/ui/pages/detection-context-explorer/pnpm-lock.yaml
+++ b/ui/pages/detection-context-explorer/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   flatted: 3.4.2
   picomatch@2: 2.3.2
   picomatch@4: 4.0.4
+  brace-expansion@1: 1.1.13
   brace-expansion@5: 5.0.5
 
 importers:
@@ -1466,8 +1467,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4907,7 +4908,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -6031,7 +6032,7 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@9.0.7:
     dependencies:


### PR DESCRIPTION
Fixes ReDoS vulnerability in brace-expansion 1.1.12 by pinning to patched version 1.1.13.