### PR TITLE
Remove personal contact email from API integration spec

### DIFF
--- a/api-integrations/Crowdstrike_alerts_and_message-center.json
+++ b/api-integrations/Crowdstrike_alerts_and_message-center.json
@@ -3734,9 +3734,6 @@
     }
   },
   "info": {
-    "contact": {
-      "email": "javier.carrasco@crowdstrike.com"
-    },
     "description": "Crowdstrike alerts and message-center APIs.",
     "title": "Crowdstrike alerts and message-center",
     "version": ""


### PR DESCRIPTION
## Summary

Removes the `info.contact.email` field from the OpenAPI spec(s) in `api-integrations/`. This field contained a personal CrowdStrike employee email address, which is inappropriate to expose in a public repository.

The field is optional per the OpenAPI specification and is not used by Foundry at runtime.

## Change

- Removed `"contact": { "email": "..." }` block from `info` section
- No functional change — spec behaviour is identical